### PR TITLE
Fix 3 failing e2e tests in nginx-hardened example

### DIFF
--- a/examples/nginx-hardened/test/e2e.bats
+++ b/examples/nginx-hardened/test/e2e.bats
@@ -35,7 +35,7 @@ EXAMPLE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
   cd "$EXAMPLE_DIR"
   run vagrant ssh -c "curl -so /dev/null -w '%{http_code}' http://localhost"
   [ "$status" -eq 0 ]
-  [[ "$output" == "200" ]]
+  [[ "$output" == *"200"* ]]
 }
 
 @test "nginx serves the default welcome page" {
@@ -83,7 +83,7 @@ EXAMPLE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
 @test "loopback interface is explicitly allowed" {
   cd "$EXAMPLE_DIR"
-  run vagrant ssh -c "sudo iptables -L INPUT -n | grep -i 'lo\|loopback\|127.0.0.1'"
+  run vagrant ssh -c "sudo iptables -S INPUT | grep -q '\-i lo'"
   [ "$status" -eq 0 ]
 }
 
@@ -105,14 +105,14 @@ EXAMPLE_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
 
 @test "saved rules contain the DROP policy" {
   cd "$EXAMPLE_DIR"
-  run vagrant ssh -c "grep -q ':INPUT DROP' /etc/iptables/rules.v4 && echo found"
+  run vagrant ssh -c "sudo grep -q ':INPUT DROP' /etc/iptables/rules.v4 && echo found"
   [ "$status" -eq 0 ]
   [[ "$output" == *"found"* ]]
 }
 
 @test "saved rules contain the SSH allow rule" {
   cd "$EXAMPLE_DIR"
-  run vagrant ssh -c "grep -q 'dport 22' /etc/iptables/rules.v4 && echo found"
+  run vagrant ssh -c "sudo grep -q 'dport 22' /etc/iptables/rules.v4 && echo found"
   [ "$status" -eq 0 ]
   [[ "$output" == *"found"* ]]
 }


### PR DESCRIPTION
## Summary

Fixes all three open issues causing e2e test failures in `examples/nginx-hardened/test/e2e.bats`.

- **Fixes #1** — Added `sudo` to `grep` commands reading `/etc/iptables/rules.v4` (tests 14 & 15); file is root-owned and unreadable without elevated privileges.
- **Fixes #2** — Replaced `iptables -L INPUT -n | grep lo` with `iptables -S INPUT | grep -q '\-i lo'` (test 11); the `-L` format omits interface columns unless `-v` is passed, but `-S` always includes `-i <iface>` flags.
- **Fixes #3** — Changed exact equality `== "200"` to glob match `== *"200"*` (test 4); `vagrant-libvirt` emits a `[fog][WARNING]` line to stdout before command output, causing the strict match to fail even when nginx returns 200.

## Test plan

- [x] Booted VM with `vagrant up` in `examples/nginx-hardened`
- [x] Ran full suite: `bats test/e2e.bats` — all 16 tests pass
- [x] Verified each previously-failing test (4, 11, 14, 15) now shows `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)