### PR TITLE
fix: Node.js 24 compat and bump to v0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 # Requires CLAWHUB_TOKEN stored as a GitHub Actions secret.
 # Setup: clawhub.ai → Account Settings → API Tokens → New Token
 # Then: GitHub repo → Settings → Secrets → Actions → CLAWHUB_TOKEN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env to `ci.yml` and `publish-clawhub.yml` to silence the Node.js 20 deprecation warning (forced to Node 24 by GitHub on June 2, 2026)
- Bump package version to `0.2.0` for first ClawHub publish

## After merging

Create the release to trigger ClawHub publish:
```bash
gh release create v0.2.0 --title "v0.2.0" --notes "Initial ClawHub publish"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)