### PR TITLE
fix: upgrade to actions/checkout@v6 and setup-node@v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,11 @@ on:
   pull_request:
     branches: [main]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
@@ -30,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install bats-core
         run: sudo apt-get install -y bats
@@ -42,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -4,9 +4,6 @@ on:
   release:
     types: [published]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 # Requires CLAWHUB_TOKEN stored as a GitHub Actions secret.
 # Setup: clawhub.ai → Account Settings → API Tokens → New Token
 # Then: GitHub repo → Settings → Secrets → Actions → CLAWHUB_TOKEN
@@ -18,7 +15,7 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install shellcheck and bats
         run: sudo apt-get install -y shellcheck bats
@@ -37,10 +34,10 @@ jobs:
   validate-skill:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -54,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint-and-test, validate-skill]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout@v4` → `@v6` (Node.js 24 native)
- Upgrades `actions/setup-node@v4` → `@v6` (Node.js 24 native)
- Removes `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround — the env var approach doesn't eliminate the deprecation warning; upgrading the actions is the proper fix

## After merging

Create the release to trigger ClawHub publish:
```bash
gh release create v0.2.0 --title "v0.2.0" --notes "Initial ClawHub publish"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)