### PR TITLE
fix: correct clawhub publish command

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -64,6 +64,6 @@ jobs:
           npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Publish to ClawHub
-        run: npx --yes clawhub@latest publish --scope @jpoley
+        run: npx --yes clawhub@latest publish .
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `--scope` is not a valid flag for `clawhub publish`
- Correct syntax is `clawhub publish <path>` — changed to `clawhub publish .`

## After merging

Delete and recreate the release to retrigger the publish workflow:
```bash
gh release delete v0.2.0 --yes && gh release create v0.2.0 --title "v0.2.0" --notes "Initial ClawHub publish"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)