### PR TITLE
fix: correct clawhub publish workflow

### DIFF
--- a/.github/workflows/publish-clawhub.yml
+++ b/.github/workflows/publish-clawhub.yml
@@ -58,12 +58,10 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Sync version from release tag
+      - name: Publish to ClawHub
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          npm version "$VERSION" --no-git-tag-version --allow-same-version
-
-      - name: Publish to ClawHub
-        run: npx --yes clawhub@latest publish --scope @jpoley
+          npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
+          npx --yes clawhub@latest publish . --version "$VERSION"
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The publish step used `--scope @jpoley` which is not a valid flag for `clawhub publish`.

## Fix

Verified locally against `clawhub@latest` (v0.9.0):

```
$ npx clawhub@latest login --help
Options:
  --token <token>   API token
  --no-browser      Do not open browser (requires --token)

$ npx clawhub@latest publish --help
Usage: clawhub publish [options] <path>
Options:
  --version <version>   Version (semver)
```

Corrected publish step:
```bash
VERSION="${GITHUB_REF_NAME#v}"
npx --yes clawhub@latest login --token "$CLAWHUB_TOKEN" --no-browser
npx --yes clawhub@latest publish . --version "$VERSION"
```

## After merging

The failed `v0.2.0` release needs to be retriggered:
```bash
gh release delete v0.2.0 --yes && git tag -d v0.2.0 && git push origin :refs/tags/v0.2.0
gh release create v0.2.0 --title "v0.2.0" --notes "Initial ClawHub publish"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)