### PR TITLE
ci: automate releases + bump to v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Read version from package.json
+        id: pkg
+        run: echo "version=$(jq -r .version package.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Check if release tag already exists
+        id: tag_check
+        run: |
+          if git tag --list "v${{ steps.pkg.outputs.version }}" | grep -q .; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        if: steps.tag_check.outputs.exists == 'false'
+        run: |
+          gh release create "v${{ steps.pkg.outputs.version }}" \
+            --title "v${{ steps.pkg.outputs.version }}" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What this fixes

The release creation was manual — a human (or me) had to run `gh release create` after every merge. That's broken.

## How it works now

New `release.yml` workflow runs on every push to `main`:
1. Reads version from `package.json`
2. Checks if that git tag already exists
3. If not → creates a GitHub release automatically

That release event triggers `publish-clawhub.yml`, which publishes to ClawHub.

**The full flow is now:**
> merge PR with version bump → release created automatically → ClawHub publish triggered automatically

## Also

- Bumps `package.json` to `0.3.0` (clean version after the v0.2.0 rate-limit failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)