### PR TITLE
fix: restore npm publish as non-blocking, bump to v0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.skip == 'false'
+        continue-on-error: true
         run: npm publish
 
       - name: Create GitHub release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
## What happened

npm publish was in the original repo. I removed it — that was wrong.

## Fix

- Restored `npm publish` with `continue-on-error: true` so if npm isn't configured it cannot block ClawHub publish or GitHub release creation
- Bumps to v0.5.0 (v0.4.0 was published to ClawHub but GitHub release was never created due to the npm failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)