### PR TITLE
fix: npm publish --provenance, bump to v0.7.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,8 +52,7 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          node-version: "24"
 
       - name: Validate Agent Skills spec
         if: steps.check.outputs.skip == 'false'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.skip == 'false'
         continue-on-error: true
-        run: npm publish
+        run: npm publish --provenance --access public
 
       - name: Create GitHub release
         if: steps.check.outputs.skip == 'false'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
OIDC trusted publishing requires \`--provenance\` flag. Without it npm doesn't use the OIDC token and auth fails with 404.

Also bumps to v0.7.0 (v0.6.0 already tagged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)