### PR TITLE
fix: npm OIDC auth, bump to v0.7.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.skip == 'false'
-        continue-on-error: true
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Validate Agent Skills spec
         if: steps.check.outputs.skip == 'false'
@@ -73,6 +74,8 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         continue-on-error: true
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ""
 
       - name: Create GitHub release
         if: steps.check.outputs.skip == 'false'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Root causes of npm 404/ENEEDAUTH

1. `actions/setup-node` with `registry-url` injects a fake `NODE_AUTH_TOKEN` placeholder — npm tries to auth with it and gets rejected as 404 ([actions/setup-node#1440](https://github.com/actions/setup-node/issues/1440), [npm/cli#8976](https://github.com/npm/cli/issues/8976))
2. Node 22 ships with npm v10 — OIDC trusted publishing requires npm 11.5.1+

## Fix

- `registry-url` kept (needed to write `.npmrc`)
- `node-version: "24"` (ships with npm 11)
- `NODE_AUTH_TOKEN: ""` on the publish step — clears the fake placeholder so OIDC takes over

🤖 Generated with [Claude Code](https://claude.com/claude-code)