### PR TITLE
fix: overwrite .npmrc to clear fake token for OIDC, v0.7.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,9 +73,9 @@ jobs:
       - name: Publish to npm
         if: steps.check.outputs.skip == 'false'
         continue-on-error: true
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ""
+        run: |
+          echo "registry=https://registry.npmjs.org/" > ~/.npmrc
+          npm publish --provenance --access public
 
       - name: Create GitHub release
         if: steps.check.outputs.skip == 'false'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daax-dev/vagrant-skill",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Disposable VMs for safe testing — Agent Skills standard skill for Claude Code, OpenClaw, and 30+ AI agents",
   "author": "JP Workspace",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Problem

`setup-node` writes `_authToken=${NODE_AUTH_TOKEN}` to `.npmrc`. Even setting `NODE_AUTH_TOKEN: ""` still leaves an empty token in `.npmrc`, causing `ENEEDAUTH` — npm sees the field and tries to use it instead of OIDC.

## Fix

Overwrite `.npmrc` with just the registry line before publishing, so the fake token is gone and `npm publish --provenance` can use OIDC:

```bash
echo "registry=https://registry.npmjs.org/" > ~/.npmrc
npm publish --provenance --access public
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)