### PR TITLE
fix: use NPM_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   release:
@@ -72,9 +71,9 @@ jobs:
 
       - name: Publish to npm
         if: steps.check.outputs.skip == 'false'
-        run: npm publish --provenance --access public
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ""
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         if: steps.check.outputs.skip == 'false'


### PR DESCRIPTION
Drop OIDC, use the existing `NPM_TOKEN` secret with `NODE_AUTH_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)