### PR TITLE
chore: optimize AI agent configuration

### DIFF
--- a/.claude/architecture.md
+++ b/.claude/architecture.md
@@ -1,0 +1,53 @@
+# Architecture
+
+Architectural decisions require operator approval before implementation.
+ADRs log to `.logs/decisions/architecture.jsonl` (see `.claude/history.md`).
+
+This repo is a **skill package**, not a networked application. There is no service
+topology, API surface, datastore, or inter-service communication. Most generic
+architecture concerns (API style, idempotency keys, cross-service clients, shared
+databases) are **N/A**. The "architecture" here is the contract between the skill,
+the `Vagrantfile`, the provisioning scripts, and the VM they produce.
+
+---
+
+## Core Design Principles
+- **General-purpose, not project-specific.** `scripts/setup.sh` installs only a baseline (system deps, Docker, Go, mage, optional KVM). Consumer projects layer their own provisioning on top. Adding project-specific tooling to the base scripts is rejected.
+- **Idempotent provisioning.** Every provisioning step must be safe to re-run; `vagrant provision` must converge to the same state. Guard installs with capability checks (`command -v ...`).
+- **Disposable by design.** The VM holds no durable state. `vagrant destroy -f` is the recovery path. The host repo is rsynced in (read copy at `/project`), never mutated by the VM.
+- **No host privilege.** All sudo/privileged operations happen inside the VM; the agent never needs host-level sudo.
+- **Multi-provider parity.** The `Vagrantfile` supports Parallels, libvirt, and VirtualBox so the skill works across macOS, Linux, and Windows/WSL2. Provider-specific knobs live in their own provider blocks.
+
+---
+
+## Boundaries / Contracts
+- **Skill ↔ host:** `SKILL.md` frontmatter declares `allowed-tools` and required bins (`metadata.openclaw.requires`). Honor these — do not assume tools outside the declared set.
+- **Vagrantfile ↔ scripts:** the provisioner is invoked from the `Vagrantfile`; keep the host/guest path contract (`/project`) and env-var interface (`VM_CPUS`, `VM_MEMORY`, `PROJECT_SRC`) stable.
+- **Tests ↔ behavior:** test boundary = behavior boundary. A behavior change must come with a bats assertion. Unit suites must not require a VM; integration/e2e suites may.
+
+---
+
+## Anti-Patterns (refuse these)
+- Project-specific tooling baked into the general-purpose `scripts/setup.sh`.
+- Non-idempotent provisioning (unconditional installs, appends without guards).
+- Persisting state in the VM that survives `vagrant destroy` and is relied upon.
+- Provider lock-in: a change that works on one provider and silently breaks the others.
+- "Temporary" workarounds without an expiry date and an owner.
+- Secrets in scripts, the `Vagrantfile`, source control, or CI variables.
+
+---
+
+## Decision Logging
+Log to `.logs/decisions/architecture.jsonl`:
+```json
+{"id":"arch-001","date":"YYYY-MM-DD","decision":"...","rationale":"...","alternatives":"...","references":["https://..."]}
+```
+
+---
+
+## Reference Architectures
+When citing patterns, prefer primary sources:
+- Vagrant official docs (developer.hashicorp.com/vagrant).
+- Agent Skills standard documentation and the `skills-ref` validator.
+- Provider docs: libvirt, VirtualBox, Parallels.
+Cite the exact URL in `.logs/references/architecture.jsonl`.

--- a/.claude/history.md
+++ b/.claude/history.md
@@ -1,0 +1,47 @@
+# History — Decision and Reference Logging
+
+All significant decisions and citable references log to disk as JSONL.
+One JSON object per line. No prose, no markdown, no commentary inside the JSON.
+
+---
+
+## Decisions
+
+**Location:** `.logs/decisions/<topic>.jsonl`
+
+**Format:**
+```json
+{"id":"<topic>-NNN","date":"YYYY-MM-DD","decision":"One-sentence statement of what was decided","rationale":"Why","alternatives":"What was considered and rejected, and why","references":["https://..."]}
+```
+
+**Rules:**
+- ID prefix matches the topic filename. IDs increment sequentially. Check the last entry before writing a new one.
+- One decision per line. No embedded newlines — keep the file `jq -c` parseable.
+- Log the decision before or immediately after acting on it. Not "later."
+- Architectural decisions require operator approval before the log entry is written.
+
+**What counts as a decision worth logging:**
+- A choice between two or more viable options.
+- A constraint, assumption, or non-obvious workaround being encoded.
+- A tool, framework, library, or service being adopted or rejected.
+- A scope boundary being set or changed.
+- Any one-way-door action.
+
+Routine code edits, typo fixes, and pure refactors do not require log entries.
+
+---
+
+## References
+
+**Location:** `.logs/references/<topic>.jsonl`
+
+**Format:**
+```json
+{"id":"ref-NNN","date":"YYYY-MM-DD","category":"official_docs|standard|article|repo|paper","title":"...","url":"...","relevance":"why this source supports the claim"}
+```
+
+**Rules:**
+- Cite every external claim. No unverifiable statistics, no "studies show…" without a link.
+- Primary authorities: official vendor docs, NIST, CIS, SLSA, DORA, OWASP, official RFCs.
+- Not citations: Medium posts, Stack Overflow answers, LLM outputs, screenshots without a URL.
+- If a source cannot be validated, state that explicitly. Do not pretend it was validated.

--- a/.claude/language.md
+++ b/.claude/language.md
@@ -35,7 +35,7 @@ For each active language, this file records:
 ---
 
 ## Skill Definition (Markdown + YAML frontmatter)
-- `SKILL.md` is validated against the Agent Skills standard via `npx --yes skills-ref validate` (CI `validate-skill` job).
+- `SKILL.md` is validated against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so the `validate-skill` CI job copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`. Running it directly from the `vagrant-skill` checkout fails on the directory-name check.
 - `test/skill.bats` asserts frontmatter fields and structure.
 - Keep `SKILL.md`, the `Vagrantfile`, and the bats suites in sync when behavior changes.
 

--- a/.claude/language.md
+++ b/.claude/language.md
@@ -35,7 +35,7 @@ For each active language, this file records:
 ---
 
 ## Skill Definition (Markdown + YAML frontmatter)
-- `SKILL.md` is validated against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so the `validate-skill` CI job copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`. Running it directly from the `vagrant-skill` checkout fails on the directory-name check.
+- `SKILL.md` is validated against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so the `validate-skill` CI job copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null || true; npx --yes skills-ref validate /tmp/vagrant`. Running it directly from the `vagrant-skill` checkout fails on the directory-name check.
 - `test/skill.bats` asserts frontmatter fields and structure.
 - Keep `SKILL.md`, the `Vagrantfile`, and the bats suites in sync when behavior changes.
 

--- a/.claude/language.md
+++ b/.claude/language.md
@@ -1,0 +1,55 @@
+# Language Conventions
+
+`[FILL IN]` marks a gap. Treat as "ask the operator," not a guess.
+
+This repo has no compiled application code. The active languages are Ruby (the
+`Vagrantfile`) and Bash (the provisioning/verification scripts). Correctness is
+validated by syntax checks, shellcheck, and bats-core suites — there is no unit
+test framework beyond bats and no coverage tooling.
+
+For each active language, this file records:
+1. Pinned version and how it is pinned.
+2. Formatter and config location.
+3. Linter and config location.
+4. Test / validation approach.
+
+---
+
+## Active Languages
+
+### Bash
+- Version target: bash 5.x (Ubuntu 24.04 guest; macOS/Linux hosts).
+- Scope: `scripts/setup.sh`, `scripts/verify.sh`, inline provisioning in `Vagrantfile`, and `examples/*/test/e2e.bats` helpers.
+- Formatter: none. Match existing style (4-space indent, aligned comment banners).
+- Linter: `shellcheck` — `make lint` runs `shellcheck scripts/setup.sh scripts/verify.sh`. Must be clean.
+- Style: `set -euo pipefail` in every script. Quote all expansions. No `eval`. All scripts must be **idempotent** (`vagrant provision` re-runs safely).
+- Validation: bats-core suites assert structure and behavior (`test/scripts.bats`).
+
+### Ruby (Vagrantfile only)
+- Version: Ruby 3.3 in CI (`ruby/setup-ruby@v1`). No `.ruby-version` file pinned in repo; the runtime Ruby is whatever Vagrant bundles when the skill is used.
+- Scope: `Vagrantfile` and `examples/*/Vagrantfile`. No application Ruby, no gems beyond Vagrant plugins (e.g. vagrant-libvirt).
+- Formatter: none.
+- Linter / validation: `ruby -c <Vagrantfile>` (`make lint` runs `ruby -c Vagrantfile`). Must report `Syntax OK`.
+- Validation: `test/vagrantfile.bats` checks required configuration (box, synced_folder, providers).
+
+---
+
+## Skill Definition (Markdown + YAML frontmatter)
+- `SKILL.md` is validated against the Agent Skills standard via `npx --yes skills-ref validate` (CI `validate-skill` job).
+- `test/skill.bats` asserts frontmatter fields and structure.
+- Keep `SKILL.md`, the `Vagrantfile`, and the bats suites in sync when behavior changes.
+
+---
+
+## Tests (bats-core)
+- Unit (no VM): `test/scripts.bats`, `test/skill.bats`, `test/vagrantfile.bats` — run by `make test` (alias `test-unit`).
+- Integration (boots a real VM, requires Vagrant + provider): `test/integration.bats` — run by `make test-integration`.
+- End-to-end examples: `examples/<name>/test/e2e.bats` — boot the example VM, run bats, tear down (`vagrant destroy -f`). bats exits non-zero on any failure.
+- No coverage threshold is enforced; correctness is asserted by the bats suites passing.
+
+---
+
+## Cross-Cutting Rules
+- No language rule overrides the linter. Fix the config or script, not by suppressing the check.
+- `Vagrantfile` is committed; `.vagrant/` and `node_modules/` are gitignored and never committed.
+- Changing skill behavior requires updating `SKILL.md` and the matching bats suite in the same change.

--- a/.claude/sourcecontrol.md
+++ b/.claude/sourcecontrol.md
@@ -1,0 +1,69 @@
+# Source Control
+
+---
+
+## Repository
+- Host: GitHub — `github.com/daax-dev/vagrant-skill`
+- Default branch: `main`
+- All work lands via PR. No direct commits to main.
+
+---
+
+## Branch Naming
+- Feature: `feature/<short-topic>`
+- Bug fix: `fix/<short-topic>`
+- Docs: `docs/<short-topic>`
+- Chore / tooling: `chore/<short-topic>`
+- Release: `release/vX.Y.Z` and version bumps `bump-X.Y.Z` (existing convention in this repo).
+- Claude Code sessions: harness-assigned name (e.g., `claude/<task>-<id>`). Do not rename mid-session.
+- Lowercase, hyphen-separated. Keep names short.
+
+---
+
+## Commits
+- Imperative mood, present tense: "add X", not "added X" or "adds X".
+- Subject line ≤ 72 characters.
+- Body explains the **why**. The diff shows the what.
+- One logical change per commit. Mixed-purpose commits get rejected at review.
+- Do not amend a commit that has already been pushed unless explicitly asked.
+
+---
+
+## Pull Requests
+- Open a PR as soon as the branch has a meaningful commit. Draft is fine.
+- PR title = leading commit subject line.
+- PR body must include:
+  - Problem statement (link the GitHub Issue when one exists).
+  - Approach taken and alternatives considered.
+  - Test evidence (commands run, output — at minimum `make lint && make test`).
+  - Which model produced and which model validated (if AI-assisted).
+- Never merge your own PR unless explicitly authorized by the operator.
+- Squash-merge by default unless the branch history is intentionally curated.
+
+---
+
+## Worktrees
+- Long-running parallel work uses `git worktree` rather than branch-switching in place.
+- Worktree paths live outside the primary checkout (e.g., `/tmp/<repo>-<branch>`).
+- Worktrees are disposable. Clean them up when the branch lands (`git worktree remove`).
+
+---
+
+## What Never Gets Committed
+- Secrets, tokens, keys, connection strings, npm publish tokens.
+- `.env` files with live values.
+- VM state (`.vagrant/`) and `node_modules/` — both gitignored.
+- IDE / OS noise (`.DS_Store`, `Thumbs.db`) — already in `.gitignore`.
+
+---
+
+## Destructive Operations
+- Force-push to a shared branch requires explicit operator authorization.
+- `git reset --hard`, branch deletion, and history rewrites require confirmation when recovery is uncertain.
+- Treat destructive git operations as high-risk: pause, verify the target, get confirmation.
+
+---
+
+## Tags and Releases
+- Tag scheme: semver `vX.Y.Z`, matching `package.json` `version` (currently 0.7.x).
+- Release flow: version-bump branch (`bump-X.Y.Z`) → PR → publish via `.github/workflows/publish.yml` to npm + ClawHub.

--- a/.claude/stack.md
+++ b/.claude/stack.md
@@ -1,0 +1,37 @@
+# Stack
+
+`[FILL IN]` marks an undefined entry. Treat as "ask the operator," not a guess.
+Only document what is confirmed and deployable today.
+
+This repo is a **skill package**, not a running service. There is no persistence,
+messaging, auth, observability, or cloud-compute tier — those sections are omitted
+deliberately. The "runtime" is the contributor toolchain plus the VM the skill provisions.
+
+---
+
+## Skill Format
+- Agent Skills standard: `SKILL.md` with YAML frontmatter (`name`, `description`, `license`, `compatibility`, `allowed-tools`, `metadata`).
+- Validated with `npx --yes skills-ref validate` (CI job `validate-skill`; validator requires the skill dir to be named `vagrant`).
+- Consumed as a Claude Code skill (`/vagrant`) and an OpenClaw skill (`metadata.openclaw` declares required bins).
+
+## Contributor Toolchain
+- Ruby — `Vagrantfile` is Ruby; validated via `ruby -c`. CI pins Ruby 3.3 (`ruby/setup-ruby@v1`). No application Ruby code, no gems beyond Vagrant plugins.
+- Bash — `scripts/setup.sh`, `scripts/verify.sh`; linted with shellcheck.
+- bats-core — test runner for `test/*.bats` and `examples/*/test/e2e.bats`.
+- Vagrant CLI + a provider — required only to run integration/e2e tests and to use the skill. Providers: Parallels (macOS Apple Silicon), libvirt (Linux, nested KVM), VirtualBox (cross-platform). Base box `bento/ubuntu-24.04`.
+
+## Provisioned VM (what the skill installs)
+- Ubuntu 24.04, full sudo, Docker CE, Go, mage, optional nested KVM. See `references/vm-contents.md` for the authoritative inventory.
+- Configurable via env vars before `vagrant up`: `VM_CPUS` (default 4), `VM_MEMORY` (default 4096 MB), `PROJECT_SRC`.
+
+## Build / Package
+- npm package `@daax-dev/vagrant-skill`; Node engine `>=22.14.0`. `package.json` `files`: `SKILL.md`, `Vagrantfile`, `scripts/`, `references/`, `LICENSE`. `publishConfig.access: public`.
+- npm `scripts` proxy to make: `lint`, `test`, `test:integration`, `test:all`.
+- CI: GitHub Actions — `.github/workflows/ci.yml` runs `lint` → (`test`, `validate-skill`) on push/PR to `main`. Release/publish via `.github/workflows/publish.yml`.
+- Artifact registries: npm (public) and ClawHub (per `package.json` keywords / publish workflow).
+
+## Explicitly Not in Stack
+List rejected tools and the reason. Prevents re-proposal.
+- Project-specific provisioning inside `scripts/setup.sh` — this is a general-purpose skill; consumers add their own tooling on top.
+- Docker Desktop — the skill deliberately provides Docker CE inside a VM to avoid Docker Desktop's commercial-license constraints (see `examples/mac-docker-compose/`).
+- Application databases / services — out of scope; this repo ships configuration and scripts, not a deployed app.

--- a/.claude/stack.md
+++ b/.claude/stack.md
@@ -11,7 +11,7 @@ deliberately. The "runtime" is the contributor toolchain plus the VM the skill p
 
 ## Skill Format
 - Agent Skills standard: `SKILL.md` with YAML frontmatter (`name`, `description`, `license`, `compatibility`, `allowed-tools`, `metadata`).
-- Validated with `npx --yes skills-ref validate` (CI job `validate-skill`; validator requires the skill dir to be named `vagrant`).
+- Validated by the `validate-skill` CI job. The validator requires the skill dir to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` before validating: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
 - Consumed as a Claude Code skill (`/vagrant`) and an OpenClaw skill (`metadata.openclaw` declares required bins).
 
 ## Contributor Toolchain

--- a/.claude/stack.md
+++ b/.claude/stack.md
@@ -11,7 +11,7 @@ deliberately. The "runtime" is the contributor toolchain plus the VM the skill p
 
 ## Skill Format
 - Agent Skills standard: `SKILL.md` with YAML frontmatter (`name`, `description`, `license`, `compatibility`, `allowed-tools`, `metadata`).
-- Validated by the `validate-skill` CI job. The validator requires the skill dir to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` before validating: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
+- Validated by the `validate-skill` CI job. The validator requires the skill dir to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` before validating: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null || true; npx --yes skills-ref validate /tmp/vagrant`.
 - Consumed as a Claude Code skill (`/vagrant`) and an OpenClaw skill (`metadata.openclaw` declares required bins).
 
 ## Contributor Toolchain

--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -45,7 +45,7 @@ Identify the source before starting. If the same task appears in multiple system
 ## Definition of Done
 A task is done only when:
 - [ ] Lint and unit tests pass: `make lint && make test` (matches CI: shellcheck + `ruby -c` + bats unit suites). When a Vagrant provider is available and VM behavior changed, also run `make test-integration` (or `make test-all`).
-- [ ] Skill changes validate against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so run the CI flow (the `validate-skill` job) rather than invoking it from the `vagrant-skill` checkout root: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
+- [ ] Skill changes validate against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so run the CI flow (the `validate-skill` job) rather than invoking it from the `vagrant-skill` checkout root: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null || true; npx --yes skills-ref validate /tmp/vagrant`.
 - [ ] PR opened with problem statement, approach, and test evidence.
 - [ ] Non-trivial decisions logged in `.logs/decisions/` per `.claude/history.md`.
 - [ ] Validation pass by a separate model — cross-provider (Claude ↔ Codex) where possible — recorded in the PR description as `Validation:` producer model + validator model + verdict (note if cross-provider was not possible).

--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -1,0 +1,52 @@
+# Workflow
+
+## Planning
+- A plan is required for any non-trivial change.
+- Trivial: typo fix, single-line config update, obvious rename. Everything else requires a plan.
+- Write the plan down — in the PR description, task system, or `.logs/decisions/`. Plans held only in chat do not count.
+- Present trade-offs as facts: option, cost, risk, reversibility. The operator decides; the agent executes.
+- Do not start coding until the plan is approved.
+
+---
+
+## Execution Discipline
+- State assumptions that affect implementation. If the request has multiple plausible readings, ask before editing.
+- Smallest change that satisfies the verified goal. No speculative features, abstractions, or config.
+- Touch only what the task requires. No adjacent cleanup or drive-by refactors. Every changed line traces to the request or its validation.
+- Remove only the orphans your change created; leave pre-existing dead code (mention it, don't delete).
+- Define a verifiable goal before coding. Add or update tests when behavior changes (bats suites under `test/`).
+- This is a general-purpose skill: keep `scripts/setup.sh` free of project-specific tooling. All scripts stay idempotent and shellcheck-clean.
+
+---
+
+## Work Intake
+Tasks originate from (check in this order):
+1. GitHub Issues — `github.com/daax-dev/vagrant-skill/issues` (active; bug reports drive fixes and PRs).
+2. Direct request from operator.
+
+Identify the source before starting. If the same task appears in multiple systems, ask which is canonical.
+
+---
+
+## Model Selection
+- Match model capability to task complexity. Do not waste large models on small tasks.
+- Code with one model; validate with a model from a **different provider where possible** (e.g., produced by Claude/Anthropic, validated by Codex/OpenAI, or vice versa). Prefer cross-provider; a different model from the same provider is the fallback; same model is last resort. Record both — producer and validator — in the PR description, and note if cross-provider was not possible.
+- Call out when a task requires a paid API call. State the cost estimate before incurring it.
+
+---
+
+## Communication
+- Report blockers immediately. No silent workarounds.
+- Surface uncertainty. State confidence level. No claims of certainty without a validated primary source.
+- Objective language. No first-person pronouns. No apologies.
+
+---
+
+## Definition of Done
+A task is done only when:
+- [ ] Lint and unit tests pass: `make lint && make test` (matches CI: shellcheck + `ruby -c` + bats unit suites). When a Vagrant provider is available and VM behavior changed, also run `make test-integration` (or `make test-all`).
+- [ ] Skill changes validate against the Agent Skills standard: `npx --yes skills-ref validate` (CI runs this as `validate-skill`).
+- [ ] PR opened with problem statement, approach, and test evidence.
+- [ ] Non-trivial decisions logged in `.logs/decisions/` per `.claude/history.md`.
+- [ ] Validation pass by a separate model — cross-provider (Claude ↔ Codex) where possible — recorded in the PR description as `Validation:` producer model + validator model + verdict (note if cross-provider was not possible).
+- [ ] Task system of record updated to done with link to PR/commit.

--- a/.claude/workflow.md
+++ b/.claude/workflow.md
@@ -45,7 +45,7 @@ Identify the source before starting. If the same task appears in multiple system
 ## Definition of Done
 A task is done only when:
 - [ ] Lint and unit tests pass: `make lint && make test` (matches CI: shellcheck + `ruby -c` + bats unit suites). When a Vagrant provider is available and VM behavior changed, also run `make test-integration` (or `make test-all`).
-- [ ] Skill changes validate against the Agent Skills standard: `npx --yes skills-ref validate` (CI runs this as `validate-skill`).
+- [ ] Skill changes validate against the Agent Skills standard. The validator requires the skill directory to be named `vagrant`, so run the CI flow (the `validate-skill` job) rather than invoking it from the `vagrant-skill` checkout root: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
 - [ ] PR opened with problem statement, approach, and test evidence.
 - [ ] Non-trivial decisions logged in `.logs/decisions/` per `.claude/history.md`.
 - [ ] Validation pass by a separate model — cross-provider (Claude ↔ Codex) where possible — recorded in the PR description as `Validation:` producer model + validator model + verdict (note if cross-provider was not possible).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,68 @@
+# Copilot Instructions
+
+GitHub Copilot reads this file automatically. Rules here are enforced in every session.
+
+---
+
+## Project
+Name: vagrant-skill (`@daax-dev/vagrant-skill`)
+Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubuntu 24.04 sandboxes with full sudo, Docker, Go, mage, and optional nested KVM for safe build/test/experimentation. Ships as a Claude Code and OpenClaw skill. `SKILL.md` is the authoritative skill spec.
+
+---
+
+## Operator Preferences
+<!-- Operator-specific. Revise or replace when applying to a different operator. -->
+- State facts only. No sugarcoating.
+- Surface problems, blockers, and risks immediately.
+- Consult before one-way-door or architectural decisions.
+- Never answer from a guess. Say so when a claim cannot be validated.
+- Objective language. No first-person pronouns. No apologies.
+
+---
+
+## Planning
+- A plan is required for any non-trivial change. Trivial = typo fix, single-line config update, obvious rename.
+- Write the plan first. Present it. Wait for approval. Do not start coding until approved.
+- Present options with trade-offs. The operator decides; the agent executes.
+
+---
+
+## Stack
+- Skill format: Agent Skills standard (`SKILL.md` with YAML frontmatter); validated via `npx skills-ref validate`.
+- VM tooling: Vagrant CLI with a provider (Parallels / libvirt / VirtualBox). Base box `bento/ubuntu-24.04`.
+- Languages: Ruby (Vagrantfile, syntax-checked with `ruby -c`; Ruby 3.3 in CI) and Bash (`scripts/*.sh`, shellcheck-linted).
+- Package: npm (`@daax-dev/vagrant-skill`), Node `>=22.14.0`; published to npm + ClawHub.
+- Test framework: bats-core.
+- CI: GitHub Actions — `lint` then `test` + `validate-skill`.
+
+---
+
+## Code Conventions
+- Bash: `set -euo pipefail` in every script. Quote all expansions. No `eval`. Must pass `shellcheck`.
+- Ruby (Vagrantfile): must pass `ruby -c`. No external gems beyond Vagrant plugins.
+- All provisioning must be **idempotent** — `vagrant provision` re-runs safely.
+- This is a **general-purpose** skill: no project-specific tooling in `scripts/setup.sh`. Consumers layer their own.
+- `Vagrantfile` is committed; `.vagrant/` is gitignored. Never commit `node_modules/` or VM state.
+- All `make lint` and `make test` must pass before declaring done.
+- When you change skill behavior, update `SKILL.md` and the matching bats tests.
+
+---
+
+## Source Control
+- Repo: `github.com/daax-dev/vagrant-skill`. Default branch `main`.
+- Never commit directly to `main`. All work lands via PR.
+- Branch naming: `feature/`, `fix/`, `docs/`, `chore/`.
+- Commits: imperative mood, present tense. Subject ≤ 72 characters. Body explains **why**.
+- PR body must include: problem statement, approach, alternatives considered, test evidence.
+- Never merge your own PR unless explicitly authorized.
+- Never commit secrets, tokens, keys, or `.env` files with live values.
+
+---
+
+## Definition of Done
+A task is done only when:
+- `make lint && make test` pass (matching CI). Run `make test-integration` / `make test-all` locally when a provider is available and VM behavior changed.
+- Skill changes validate (`npx --yes skills-ref validate`).
+- PR opened with problem statement, approach, and test evidence.
+- No `[FILL IN]` placeholders left in affected files.
+- Decisions logged in `.logs/decisions/` if a non-trivial choice was made.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubunt
 ---
 
 ## Stack
-- Skill format: Agent Skills standard (`SKILL.md` with YAML frontmatter); validated via `npx skills-ref validate`.
+- Skill format: Agent Skills standard (`SKILL.md` with YAML frontmatter); validated by the `validate-skill` CI job. The validator requires the skill directory to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
 - VM tooling: Vagrant CLI with a provider (Parallels / libvirt / VirtualBox). Base box `bento/ubuntu-24.04`.
 - Languages: Ruby (Vagrantfile, syntax-checked with `ruby -c`; Ruby 3.3 in CI) and Bash (`scripts/*.sh`, shellcheck-linted).
 - Package: npm (`@daax-dev/vagrant-skill`), Node `>=22.14.0`; published to npm + ClawHub.
@@ -62,7 +62,7 @@ Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubunt
 ## Definition of Done
 A task is done only when:
 - `make lint && make test` pass (matching CI). Run `make test-integration` / `make test-all` locally when a provider is available and VM behavior changed.
-- Skill changes validate (`npx --yes skills-ref validate`).
+- Skill changes validate via the CI flow (validator requires the dir named `vagrant`): `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
 - PR opened with problem statement, approach, and test evidence.
 - No `[FILL IN]` placeholders left in affected files.
 - Decisions logged in `.logs/decisions/` if a non-trivial choice was made.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubunt
 ---
 
 ## Stack
-- Skill format: Agent Skills standard (`SKILL.md` with YAML frontmatter); validated by the `validate-skill` CI job. The validator requires the skill directory to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
+- Skill format: Agent Skills standard (`SKILL.md` with YAML frontmatter); validated by the `validate-skill` CI job. The validator requires the skill directory to be named `vagrant`, so CI copies the checkout to `/tmp/vagrant` first: `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null || true; npx --yes skills-ref validate /tmp/vagrant`.
 - VM tooling: Vagrant CLI with a provider (Parallels / libvirt / VirtualBox). Base box `bento/ubuntu-24.04`.
 - Languages: Ruby (Vagrantfile, syntax-checked with `ruby -c`; Ruby 3.3 in CI) and Bash (`scripts/*.sh`, shellcheck-linted).
 - Package: npm (`@daax-dev/vagrant-skill`), Node `>=22.14.0`; published to npm + ClawHub.
@@ -62,7 +62,7 @@ Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubunt
 ## Definition of Done
 A task is done only when:
 - `make lint && make test` pass (matching CI). Run `make test-integration` / `make test-all` locally when a provider is available and VM behavior changed.
-- Skill changes validate via the CI flow (validator requires the dir named `vagrant`): `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`.
+- Skill changes validate via the CI flow (validator requires the dir named `vagrant`): `mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null || true; npx --yes skills-ref validate /tmp/vagrant`.
 - PR opened with problem statement, approach, and test evidence.
-- No `[FILL IN]` placeholders left in affected files.
+- No unresolved `[FILL IN]` placeholders left in affected files (the literal marker may remain in `.claude/stack.md` and `.claude/language.md`, where it documents the convention).
 - Decisions logged in `.logs/decisions/` if a non-trivial choice was made.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+<!-- CLAUDE.md and AGENTS.md share the Operator Preferences and Hard Guardrails below. Keep them in sync. -->
+
+# AGENTS.md
+
+Entry point for OpenAI Codex and compatible agents.
+
+---
+
+## Project
+Name: vagrant-skill (`@daax-dev/vagrant-skill`)
+Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) providing Ubuntu 24.04 sandboxes with full sudo, Docker, Go, mage, and optional nested KVM for safe build/test/experimentation. Ships as a Claude Code and OpenClaw skill.
+
+`SKILL.md` is the authoritative skill specification. Read it before changing skill behavior.
+
+---
+
+## Operator Preferences
+<!-- Operator-specific. Revise or replace when applying to a different operator. -->
+- State facts only. No sugarcoating.
+- Surface problems, blockers, and risks immediately.
+- Consult before one-way-door decisions and before any architectural change.
+- Never guess. If validation is not possible, say so explicitly.
+- Objective language. No first-person pronouns. No apologies or hedges.
+
+---
+
+## Hard Guardrails (always apply)
+- Plan before any non-trivial change. Write the plan down. Wait for approval.
+- Never commit or merge directly to `main`.
+- Never commit secrets, tokens, keys, or `.env` files with live values.
+- No destructive git (`reset --hard`, force-push, branch delete) without explicit operator approval.
+- Never overwrite uncommitted user changes. Inspect existing patterns before editing.
+- Run formatter, linter, and tests after changes. If that is not possible, state exactly why.
+- Log non-trivial decisions to `.logs/decisions/<topic>.jsonl`.
+- Repo-local instructions override these template defaults.
+
+---
+
+## Skill-Specific Rules (this repo)
+- General-purpose skill: no project-specific tooling in `scripts/setup.sh`. Consumers add their own provisioning.
+- All scripts idempotent (`vagrant provision` is re-run-safe) and shellcheck-clean. `Vagrantfile` passes `ruby -c`.
+- `Vagrantfile` is committed; `.vagrant/` is gitignored.
+
+---
+
+## Repository Layout
+- `SKILL.md` — Agent Skills standard skill definition (frontmatter + execution instructions + examples). Authoritative spec.
+- `Vagrantfile` — Ruby VM config, multi-provider (Parallels, libvirt, VirtualBox).
+- `scripts/setup.sh` — bash provisioner (system deps, Docker, Go, mage, optional KVM).
+- `scripts/verify.sh` — bash validation suite run inside the VM.
+- `test/` — bats-core suites: `scripts.bats`, `skill.bats`, `vagrantfile.bats` (unit, no VM); `integration.bats` (boots a VM).
+- `references/` — `platform-setup.md`, `vm-contents.md`.
+- `examples/` — `nginx-hardened/`, `mac-docker-compose/`, `windows-systemd-service/` (each with its own `Vagrantfile` + `test/e2e.bats`).
+- `docs/` — supplementary reference docs.
+- `Makefile` — `lint`, `test` (= `test-unit`), `test-integration`, `test-all`, `up`, `destroy`, `clean`.
+- `package.json` — npm package metadata; scripts proxy to `make`.
+- `.github/workflows/` — `ci.yml` (lint → test + validate-skill), `publish.yml` (release).
+
+---
+
+## Required Reading
+`.claude/workflow.md` — planning and definition of done — applies to every task. Read it before starting work.
+
+Read the matching file **before** you:
+- write or edit code → `.claude/language.md` (formatting, linting, testing for that language)
+- make an architectural or cross-boundary decision → `.claude/architecture.md`
+- touch dependencies, runtime, or infrastructure → `.claude/stack.md`
+- perform branch / PR / commit / merge operations → `.claude/sourcecontrol.md`
+- write a decision or reference log entry → `.claude/history.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,56 +1,71 @@
-# CLAUDE.md — vagrant-skill
+# CLAUDE.md
 
-## What This Is
+## Project
+Name: vagrant-skill (`@daax-dev/vagrant-skill`)
+Purpose: A general-purpose disposable-VM Agent Skill (`vagrant`) that gives AI agents and developers Ubuntu 24.04 sandboxes with full sudo, Docker, Go, mage, and optional nested KVM — build, test, and break things without touching the host.
+Goal: A correct, idempotent, shellcheck-clean skill package that installs cleanly as a Claude Code / OpenClaw skill and validates against the Agent Skills standard, with `make lint && make test` green and the bats e2e examples passing on a real provider.
 
-A general-purpose disposable VM skill for AI agents and developers. Provides Ubuntu 24.04 VMs with full sudo, Docker, Go, mage, and optional nested KVM.
+`SKILL.md` is the authoritative skill specification (frontmatter, execution instructions, examples). Read it before changing skill behavior.
 
-Works as both a Claude Code skill (`/vagrant`) and an OpenClaw skill.
+---
 
-## Key Commands
+## Operator Preferences
+- State facts only. No sugarcoating.
+- Surface problems, blockers, and risks immediately.
+- Consult before one-way-door decisions and before any architectural change.
+- Never answer from a guess. Validate claims against primary sources. If validation is not possible, say so explicitly.
+- Objective language. No first-person pronouns. No apologies or hedges.
 
+---
+
+## Hard Guardrails (always apply)
+- Plan before any non-trivial change. Write the plan down. Wait for approval.
+- Never commit or merge directly to `main`.
+- Never commit secrets, tokens, keys, or `.env` files with live values.
+- No destructive git (`reset --hard`, force-push, branch delete) without explicit operator approval.
+- Never overwrite uncommitted user changes. Inspect existing patterns before editing.
+- Run formatter, linter, and tests after changes. If that is not possible, state exactly why.
+- Log non-trivial decisions to `.logs/decisions/<topic>.jsonl`.
+- Repo-local instructions override these template defaults.
+
+---
+
+## Skill-Specific Rules (this repo)
+- This is a **general-purpose** skill. No project-specific tooling in `scripts/setup.sh` — consumer projects add their own provisioning on top.
+- All scripts must be **idempotent** — `vagrant provision` must be safe to re-run.
+- All shell scripts must pass **shellcheck**. `Vagrantfile` must pass `ruby -c`.
+- The `Vagrantfile` is committed (reusable infra); `.vagrant/` stays gitignored.
+
+### Key Commands
 ```bash
-# Start VM
-vagrant up
+vagrant up                       # boot VM (project synced at /project)
 PROJECT_SRC=~/myproject vagrant up
-
-# Run commands inside
-vagrant ssh -c "command here"
-
-# Sync changes
-vagrant rsync
-
-# Destroy
-vagrant destroy -f
-
-# Re-provision
-vagrant provision
+vagrant ssh -c "command here"    # run inside the VM
+vagrant rsync                    # sync host changes into the VM
+vagrant provision                # re-run provisioner (idempotent)
+vagrant destroy -f               # full teardown, clean slate
 ```
 
-## File Layout
-
-- `Vagrantfile` — VM config, multi-provider (libvirt + VirtualBox)
+### File Layout
+- `Vagrantfile` — VM config, multi-provider (Parallels + libvirt + VirtualBox)
 - `SKILL.md` — Agent Skills standard skill definition
-- `scripts/setup.sh` — Provisioner (system deps, Docker, Go, mage, KVM)
-- `scripts/verify.sh` — Validation suite
-- `test/` — Tests (bats-core)
-- `docs/` — Reference docs
+- `scripts/setup.sh` — provisioner (system deps, Docker, Go, mage, KVM)
+- `scripts/verify.sh` — validation suite
+- `test/` — bats-core tests (`scripts.bats`, `skill.bats`, `vagrantfile.bats`, `integration.bats`)
+- `references/` — provider setup and VM-contents reference docs
+- `examples/` — three working e2e examples (nginx-hardened, mac-docker-compose, windows-systemd-service)
+- `.claude/skills/vagrant/SKILL.md` — installed skill payload (not agent config; leave alone unless changing the skill)
 
-## Testing
+---
 
-```bash
-# Run all tests
-make test
+## Required Reading
+`.claude/workflow.md` is always loaded (see include below) — planning and definition of done apply to every task.
 
-# Shellcheck
-make lint
+Read the matching file **before** you:
+- write or edit code → `.claude/language.md` (formatting, linting, testing for that language)
+- make an architectural or cross-boundary decision → `.claude/architecture.md`
+- touch dependencies, runtime, or infrastructure → `.claude/stack.md`
+- perform branch / PR / commit / merge operations → `.claude/sourcecontrol.md`
+- write a decision or reference log entry → `.claude/history.md`
 
-# Full integration (requires Vagrant + provider)
-make test-integration
-```
-
-## Rules
-
-- No project-specific tooling in setup.sh (this is general-purpose)
-- Consumer projects add their own provisioning on top
-- All scripts must be idempotent
-- All scripts must pass shellcheck
+@.claude/workflow.md


### PR DESCRIPTION
## Summary
Replaces single Claude-focused guidance with a multi-agent configuration set covering Claude, Codex-compatible agents, and Copilot:
- `CLAUDE.md` — top-level Claude entry point with repo-specific rules and `.claude/*` include chain.
- `AGENTS.md` + `.github/copilot-instructions.md` — Codex-compatible and Copilot guidance.
- `.claude/*.md` — workflow, stack, source control, language conventions, history logging, architecture.

## Addressed Copilot feedback from #22 (4 comments)
All four comments flagged the same accurate issue: the `skills-ref validate` command needs the CI directory-name workaround (validator requires the skill dir named `vagrant`, but the checkout is `vagrant-skill`). Each now references the CI `validate-skill` temp-directory flow (`mkdir -p /tmp/vagrant && cp -r ./* ./.* /tmp/vagrant/ 2>/dev/null; npx --yes skills-ref validate /tmp/vagrant`):
- `.claude/workflow.md:48`
- `.claude/language.md:38`
- `.claude/stack.md:14`
- `.github/copilot-instructions.md:31` (also fixed the same issue on line 65, the suppressed low-confidence comment)

Verified against `.github/workflows/ci.yml`. Skill payload/source untouched.

Validation: producer Claude Opus 4.7 / self-review.