### PR TITLE
ci(runners): route all jobs to self-hosted Default runner group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
     steps:
       - uses: actions/checkout@v6
 
@@ -24,7 +25,8 @@ jobs:
         run: make lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
     needs: lint
     steps:
       - uses: actions/checkout@v6
@@ -36,7 +38,8 @@ jobs:
         run: make test
 
   validate-skill:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
     needs: lint
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,8 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: Default
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Flip every job's `runs-on` to the org's self-hosted "Default" runner group.