### PR TITLE
ci(runners): route CI jobs to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
 
@@ -24,7 +24,7 @@ jobs:
         run: make lint
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: lint
     steps:
       - uses: actions/checkout@v6
@@ -36,7 +36,7 @@ jobs:
         run: make test
 
   validate-skill:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: lint
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Route CI jobs to the self-hosted runner pool, matching the daax-web reference (`runs-on: self-hosted`), so PRs stop consuming GitHub-hosted Actions minutes.

Supersedes the earlier `ci/self-hosted-default-group` PR, which used `runs-on: { group: Default }` — that syntax left jobs queued for 14h+ on some repos. This uses the proven daax-web label form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)